### PR TITLE
Update tgbotapi to v3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![Build Status](https://travis-ci.org/zhulik/margelet.svg?branch=master)](https://travis-ci.org/zhulik/margelet)
 # Margelet
-Telegram Bot Framework for Go is based on [telegram-bot-api](https://gopkg.in/telegram-bot-api.v2)
+Telegram Bot Framework for Go is based on [telegram-bot-api](https://gopkg.in/telegram-bot-api.v3)
 
 It uses Redis to store it's states, configs and so on.
 
 Any low-level interactions with Telegram Bot API(downloading files, keyboards and so on) should be performed through
-[telegram-bot-api](https://"gopkg.in/telegram-bot-api.v2").
+[telegram-bot-api](https://"gopkg.in/telegram-bot-api.v3").
 
 Margelet is just a thin layer, that allows you to solve
 basic bot tasks quickly and easy.
@@ -198,7 +198,7 @@ package margelet_test
 
 import (
 	"github.com/zhulik/margelet"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 type InlineImage struct {

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -7,7 +7,7 @@ import (
 	"../margelet"
 
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 func TestAuthorization(t *testing.T) {

--- a/chat_config_repository.go
+++ b/chat_config_repository.go
@@ -20,34 +20,34 @@ func newChatConfigRepository(prefix string, redis *redis.Client) *ChatConfigRepo
 }
 
 // Set - stores any config for chatID
-func (chatConfig *ChatConfigRepository) Set(chatID int, JSON string) {
+func (chatConfig *ChatConfigRepository) Set(chatID int64, JSON string) {
 	chatConfig.redis.Set(chatConfig.ketFor(chatID), JSON, 0)
 }
 
 // SetWithStruct - stores any config for chatID using a struct
-func (chatConfig *ChatConfigRepository) SetWithStruct(chatID int, obj interface{}) {
+func (chatConfig *ChatConfigRepository) SetWithStruct(chatID int64, obj interface{}) {
 	valueBytes, _ := json.Marshal(obj)
 	valueString := string(valueBytes)
 	chatConfig.Set(chatID, valueString)
 }
 
 // Remove - removes config for chatID
-func (chatConfig *ChatConfigRepository) Remove(chatID int) {
+func (chatConfig *ChatConfigRepository) Remove(chatID int64) {
 	chatConfig.redis.Del(chatConfig.ketFor(chatID))
 }
 
 // Get - returns config for chatID
-func (chatConfig *ChatConfigRepository) Get(chatID int) string {
+func (chatConfig *ChatConfigRepository) Get(chatID int64) string {
 	json, _ := chatConfig.redis.Get(chatConfig.ketFor(chatID)).Result()
 	return json
 }
 
 // GetWithStruct - returns config for chatID using a struct
-func (chatConfig *ChatConfigRepository) GetWithStruct(chatID int, obj interface{}) {
+func (chatConfig *ChatConfigRepository) GetWithStruct(chatID int64, obj interface{}) {
 	valueString := chatConfig.Get(chatID)
 	json.Unmarshal([]byte(valueString), obj)
 }
 
-func (chatConfig *ChatConfigRepository) ketFor(chatID int) string {
+func (chatConfig *ChatConfigRepository) ketFor(chatID int64) string {
 	return fmt.Sprintf("%s_%d", chatConfig.key, chatID)
 }

--- a/chat_repository.go
+++ b/chat_repository.go
@@ -16,20 +16,20 @@ func newChatRepository(prefix string, redis *redis.Client) *chatRepository {
 	return &chatRepository{key, redis}
 }
 
-func (chat *chatRepository) Add(id int) {
-	chat.redis.SAdd(chat.key, strconv.Itoa(id))
+func (chat *chatRepository) Add(id int64) {
+	chat.redis.SAdd(chat.key, strconv.FormatInt(id, 10))
 }
 
-func (chat *chatRepository) Remove(id int) {
-	chat.redis.SRem(chat.key, strconv.Itoa(id))
+func (chat *chatRepository) Remove(id int64) {
+	chat.redis.SRem(chat.key, strconv.FormatInt(id, 10))
 }
 
-func (chat *chatRepository) All() []int {
-	var result []int
+func (chat *chatRepository) All() []int64 {
+	var result []int64
 	strings, _ := chat.redis.SMembers(chat.key).Result()
 
 	for _, str := range strings {
-		if c, err := strconv.Atoi(str); err == nil {
+		if c, err := strconv.ParseInt(str, 10, 64); err == nil {
 			result = append(result, c)
 		}
 	}

--- a/chat_repository_test.go
+++ b/chat_repository_test.go
@@ -12,7 +12,7 @@ func TestChatRepository(t *testing.T) {
 		Convey("When new chat added", func() {
 			m.ChatRepository.Add(100500)
 			Convey("New chat should be found in repo", func() {
-				So(m.ChatRepository.All(), ShouldResemble, []int{100500})
+				So(m.ChatRepository.All(), ShouldResemble, []int64{100500})
 			})
 		})
 
@@ -26,12 +26,12 @@ func TestChatRepository(t *testing.T) {
 				m.ChatRepository.Remove(100500)
 
 				Convey("Removed chat should not be found in repo", func() {
-					So(m.ChatRepository.All(), ShouldResemble, []int{100501, 100502, 100503})
+					So(m.ChatRepository.All(), ShouldResemble, []int64{100501, 100502, 100503})
 				})
 			})
 
 			Convey("Repo should return all chats", func() {
-				So(m.ChatRepository.All(), ShouldResemble, []int{100500, 100501, 100502, 100503})
+				So(m.ChatRepository.All(), ShouldResemble, []int64{100500, 100501, 100502, 100503})
 			})
 		})
 	})

--- a/echo_handler_test.go
+++ b/echo_handler_test.go
@@ -2,7 +2,7 @@ package margelet_test
 
 import (
 	"../margelet"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 // EchoHandler is simple handler example

--- a/help_handler.go
+++ b/help_handler.go
@@ -2,7 +2,7 @@ package margelet
 
 import (
 	"fmt"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 	"strings"
 )
 

--- a/inline_image_test.go
+++ b/inline_image_test.go
@@ -2,7 +2,7 @@ package margelet_test
 
 import (
 	"../margelet"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 type InlineImage struct {

--- a/interfaces.go
+++ b/interfaces.go
@@ -2,7 +2,7 @@ package margelet
 
 import (
 	"gopkg.in/redis.v3"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 // MessageHandler - interface for message handlers
@@ -32,8 +32,8 @@ type SessionHandler interface {
 type MargeletAPI interface {
 	Send(c tgbotapi.Chattable) (tgbotapi.Message, error)
 	AnswerInlineQuery(config tgbotapi.InlineConfig) (tgbotapi.APIResponse, error)
-	QuickSend(chatID int, message string) (tgbotapi.Message, error)
-	QuickReply(chatID, messageID int, message string) (tgbotapi.Message, error)
+	QuickSend(chatID int64, message string) (tgbotapi.Message, error)
+	QuickReply(chatID int64, messageID int, message string) (tgbotapi.Message, error)
 	GetFileDirectURL(fileID string) (string, error)
 	IsMessageToMe(message tgbotapi.Message) bool
 	GetConfigRepository() *ChatConfigRepository

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,7 @@ package margelet_test
 import (
 	"../margelet"
 
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 type BotMock struct {

--- a/margelet.go
+++ b/margelet.go
@@ -2,7 +2,7 @@ package margelet
 
 import (
 	"gopkg.in/redis.v3"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 type policies []AuthorizationPolicy
@@ -119,12 +119,12 @@ func (margelet *Margelet) AnswerInlineQuery(config tgbotapi.InlineConfig) (tgbot
 }
 
 // QuickSend - quick send text message to chatID
-func (margelet *Margelet) QuickSend(chatID int, message string) (tgbotapi.Message, error) {
+func (margelet *Margelet) QuickSend(chatID int64, message string) (tgbotapi.Message, error) {
 	return margelet.bot.Send(tgbotapi.NewMessage(chatID, message))
 }
 
 // QuickReply - quick send text reply to message
-func (margelet *Margelet) QuickReply(chatID, messageID int, message string) (tgbotapi.Message, error) {
+func (margelet *Margelet) QuickReply(chatID int64, messageID int, message string) (tgbotapi.Message, error) {
 	msg := tgbotapi.NewMessage(chatID, message)
 	msg.ReplyToMessageID = messageID
 	return margelet.bot.Send(msg)

--- a/margelet_test.go
+++ b/margelet_test.go
@@ -6,7 +6,7 @@ import (
 
 	"../margelet"
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 func TestMargelet(t *testing.T) {

--- a/panic_handler_test.go
+++ b/panic_handler_test.go
@@ -2,7 +2,7 @@ package margelet_test
 
 import (
 	"../margelet"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 // PanicHandler - test handler that panics

--- a/session_repository.go
+++ b/session_repository.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"gopkg.in/redis.v3"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 	"strings"
 )
 
 // SessionRepository - public interface for session repository
 type SessionRepository interface {
-	Create(chatID int, userID int, command string)
-	Add(chatID int, userID int, message tgbotapi.Message)
-	Remove(chatID int, userID int)
-	Command(chatID int, userID int) string
-	Dialog(chatID int, userID int) (messages []tgbotapi.Message)
+	Create(chatID int64, userID int, command string)
+	Add(chatID int64, userID int, message tgbotapi.Message)
+	Remove(chatID int64, userID int)
+	Command(chatID int64, userID int) string
+	Dialog(chatID int64, userID int) (messages []tgbotapi.Message)
 }
 
 type sessionRepository struct {
@@ -28,13 +28,13 @@ func newSessionRepository(prefix string, redis *redis.Client) *sessionRepository
 }
 
 // Create - creates new session for chatID, userID and command
-func (session *sessionRepository) Create(chatID int, userID int, command string) {
+func (session *sessionRepository) Create(chatID int64, userID int, command string) {
 	key := session.keyFor(chatID, userID)
 	session.redis.Set(key, command, 0)
 }
 
 // Add - adds user's answer to existing session
-func (session *sessionRepository) Add(chatID int, userID int, message tgbotapi.Message) {
+func (session *sessionRepository) Add(chatID int64, userID int, message tgbotapi.Message) {
 	key := session.dialogKeyFor(chatID, userID)
 
 	json, _ := json.Marshal(message)
@@ -43,7 +43,7 @@ func (session *sessionRepository) Add(chatID int, userID int, message tgbotapi.M
 }
 
 // Remove - removes session
-func (session *sessionRepository) Remove(chatID int, userID int) {
+func (session *sessionRepository) Remove(chatID int64, userID int) {
 	key := session.keyFor(chatID, userID)
 	session.redis.Del(key)
 
@@ -53,14 +53,14 @@ func (session *sessionRepository) Remove(chatID int, userID int) {
 
 // Command - returns command for active session for chatID and userID, if exists
 // otherwise returns empty string
-func (session *sessionRepository) Command(chatID int, userID int) string {
+func (session *sessionRepository) Command(chatID int64, userID int) string {
 	key := session.keyFor(chatID, userID)
 	value, _ := session.redis.Get(key).Result()
 	return value
 }
 
 // Dialog returns all user's answers history for chatID and userID
-func (session *sessionRepository) Dialog(chatID int, userID int) (messages []tgbotapi.Message) {
+func (session *sessionRepository) Dialog(chatID int64, userID int) (messages []tgbotapi.Message) {
 	key := session.dialogKeyFor(chatID, userID)
 
 	values := session.redis.LRange(key, 0, -1).Val()
@@ -72,10 +72,10 @@ func (session *sessionRepository) Dialog(chatID int, userID int) (messages []tgb
 	return
 }
 
-func (session *sessionRepository) keyFor(chatID int, userID int) string {
+func (session *sessionRepository) keyFor(chatID int64, userID int) string {
 	return fmt.Sprintf("%s_%d_%d", session.key, chatID, userID)
 }
 
-func (session *sessionRepository) dialogKeyFor(chatID int, userID int) string {
+func (session *sessionRepository) dialogKeyFor(chatID int64, userID int) string {
 	return fmt.Sprintf("%s_dialog", session.keyFor(chatID, userID))
 }

--- a/session_repository_test.go
+++ b/session_repository_test.go
@@ -2,7 +2,7 @@ package margelet_test
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 	"testing"
 )
 

--- a/sum_session_test.go
+++ b/sum_session_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"../margelet"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 // SumSession - simple example session, that can sum numbers

--- a/update_handlers.go
+++ b/update_handlers.go
@@ -3,7 +3,7 @@ package margelet
 import (
 	"strings"
 
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 func handleUpdate(margelet *Margelet, update tgbotapi.Update) {

--- a/username_authorization_policy.go
+++ b/username_authorization_policy.go
@@ -2,7 +2,7 @@ package margelet
 
 import (
 	"fmt"
-	"gopkg.in/telegram-bot-api.v2"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 // UsernameAuthorizationPolicy - simple authorization policy, that checks sender's username


### PR DESCRIPTION
Telegram Chat IDs for supergroups may overflow an int, as they can reach values from -1e13 to 1e13 according to the Telegram documentation. 

This PR updates margelet to use tgbotapi v3 which uses int64 Chat IDs instead. 