### PR TITLE
fix help_handler

### DIFF
--- a/help_handler.go
+++ b/help_handler.go
@@ -15,11 +15,11 @@ type HelpHandler struct {
 func (handler HelpHandler) HandleCommand(bot MargeletAPI, message *tgbotapi.Message) error {
 	lines := []string{}
 	for command, h := range handler.Margelet.CommandHandlers {
-		lines = append(lines, fmt.Sprintf("%s - %s", command, h.handler.HelpMessage()))
+		lines = append(lines, fmt.Sprintf("/%s - %s", command, h.handler.HelpMessage()))
 	}
 
 	for command, h := range handler.Margelet.SessionHandlers {
-		lines = append(lines, fmt.Sprintf("%s - %s", command, h.handler.HelpMessage()))
+		lines = append(lines, fmt.Sprintf("/%s - %s", command, h.handler.HelpMessage()))
 	}
 
 	_, err := bot.Send(tgbotapi.NewMessage(message.Chat.ID, strings.Join(lines, "\n")))


### PR DESCRIPTION
Исправляет поведение подсвечивая команды в диалоге справки.

до-после.

![help-handler-update](https://cloud.githubusercontent.com/assets/201306/14570090/d20e7ff4-035b-11e6-94f7-f98f6fad1e75.png)
