### PR TITLE
Fixed go get url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Margelet is just a thin layer, that allows you to solve
 basic bot tasks quickly and easy.
 
 ## Installation
-`go get https://github.com/zhulik/margelet`
+`go get github.com/zhulik/margelet`
 
 ## Simple usage
 ```go


### PR DESCRIPTION
The prefix "https://" needs to be removed from the package url to prevent errors thrown by "go get".